### PR TITLE
Fix Ticket #1: Return 201 Created status and correct Item model usage

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/Isentry_Backend_Test.iml
+++ b/.idea/Isentry_Backend_Test.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,12 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="restaurant.views.Customer" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.12 (Isentry_Backend_Test)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12 (Isentry_Backend_Test)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Isentry_Backend_Test.iml" filepath="$PROJECT_DIR$/.idea/Isentry_Backend_Test.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/crud/item.py
+++ b/app/crud/item.py
@@ -1,14 +1,15 @@
-from app.models import item
+
+from app.models.item import Item
 from sqlalchemy.orm import Session
 
 def get_item(db: Session, item_id: int):
-    return db.query(item).get(item_id)
+    return db.query(Item).get(item_id)
 
 def get_items(db: Session, skip: int=0, limit: int=10):
-    return db.query(item).offset(skip).limit(limit).all()
+    return db.query(Item).offset(skip).limit(limit).all()
 
 def create_item(db: Session, item_create):
-    db_item = item(name=item_create.name, description=item_create.description)
+    db_item = Item(name=item_create.name, description=item_create.description)
     db.add(db_item)
     db.commit()
     db.refresh(db_item)

--- a/app/models/item.py
+++ b/app/models/item.py
@@ -1,8 +1,8 @@
-from sqlalchemy import Colum, Integer, String
+from sqlalchemy import Column, Integer, String
 from app.db.database import Base
 
 class Item(Base):
     __tablename__ = "item"
-    id = Colum(Integer, primary_key=True, index=True)
-    name = Colum(String, nullable=False, unique=True)
-    description = Colum(String, nullable=True)
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False, unique=True)
+    description = Column(String, nullable=True)

--- a/app/routers/item.py
+++ b/app/routers/item.py
@@ -13,10 +13,13 @@ def get_db():
     finally:
         db.close() 
 
-@router.post("/items/", response_model=ItemSchema)
+@router.post("/items/", response_model=ItemSchema, status_code=201)
 def create_item(item_create: ItemCreate, db: Session = Depends(get_db)):
     return item.create_item(db, item_create)
+
 
 @router.get("/items/", response_model=list[ItemSchema])
 def read_items(skip: int=0, limit: int=10, db: Session = Depends(get_db)):
     return item.get_items(db, skip=skip, limit=limit)
+
+

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -5,10 +5,12 @@ client = TestClient(app)
 
 def test_create_item():
     response = client.post("/items/", json={"name": "Test", "description": "A test"})
-    assert response.status_code == 200
+    assert response.status_code == 201
     assert response.json()["name"] == "Test"
 
 def test_read_items():
     response = client.get("/items/")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
+
+


### PR DESCRIPTION
Closes #1

Issue:
The test for creating a new item was failing because the API was returning the wrong status code, and the CRUD call used the module instead of the model class.

Changes:
- Updated `create_item` in `app/crud/item.py` to use the correct model class.
- Endpoint now correctly returns `201 Created`.
- Test updated to expect `201` instead of a different status code.

Outcome:
The API now creates items correctly, and the test for item creation passes.
