### PR TITLE
Fix Ticket #4: Add ORM mode to Item Pydantic schema

### DIFF
--- a/app/schemas/item.py
+++ b/app/schemas/item.py
@@ -2,10 +2,14 @@ from pydantic import BaseModel
 
 class ItemBase(BaseModel):
     name: str
-    description: str = None
+    description: str | None = None
 
 class ItemCreate(ItemBase):
     pass
 
 class ItemSchema(ItemBase):
     id: int
+
+    class Config:
+        orm_mode = True
+


### PR DESCRIPTION
Closes #4

Issue:
The Pydantic schema `ItemSchema` was not correctly configured to work with SQLAlchemy ORM models. As a result, the API could not serialize and return item data correctly.

Changes:
- Added `class Config: orm_mode = True` to `ItemSchema` in `app/schemas/item.py`.  
- Updated the `description` field typing to `str | None` for better clarity.

Outcome:
FastAPI can now return ORM-based item objects correctly, resolving serialization issues.
