### PR TITLE
Fix issue #4: Add ORM mode to Item Pydantic schema 

### DIFF
--- a/app/crud/item.py
+++ b/app/crud/item.py
@@ -1,15 +1,17 @@
-from app.models import item
+from app.models.item import Item
 from sqlalchemy.orm import Session
 
 def get_item(db: Session, item_id: int):
-    return db.query(item).get(item_id)
+    return db.query(Item).get(item_id)
 
 def get_items(db: Session, skip: int=0, limit: int=10):
-    return db.query(item).offset(skip).limit(limit).all()
+    return db.query(Item).offset(skip).limit(limit).all()
+
 
 def create_item(db: Session, item_create):
-    db_item = item(name=item_create.name, description=item_create.description)
+    db_item = Item(name=item_create.name, description=item_create.description)
     db.add(db_item)
     db.commit()
     db.refresh(db_item)
     return db_item
+

--- a/app/models/item.py
+++ b/app/models/item.py
@@ -1,8 +1,8 @@
-from sqlalchemy import Colum, Integer, String
+from sqlalchemy import Column, Integer, String
 from app.db.database import Base
 
 class Item(Base):
     __tablename__ = "item"
-    id = Colum(Integer, primary_key=True, index=True)
-    name = Colum(String, nullable=False, unique=True)
-    description = Colum(String, nullable=True)
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False, unique=True)
+    description = Column(String, nullable=True)

--- a/app/schemas/item.py
+++ b/app/schemas/item.py
@@ -9,3 +9,6 @@ class ItemCreate(ItemBase):
 
 class ItemSchema(ItemBase):
     id: int
+
+class Config:
+        orm_mode = True


### PR DESCRIPTION
Issue:
The Pydantic schema ItemSchema was not correctly configured to work with SQLAlchemy ORM models
Changes:
Added class Config: orm_mode = True to ItemSchema in app/schemas/item.py


Closes #4 